### PR TITLE
Install ACL package for privilege escalation on Linux systems

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -51,7 +51,7 @@
       ansible.builtin.package:
         name: acl
         state: present
-      when: is_linux and not is_macos
+      when: is_linux
 
     - name: Check if running as root
       ansible.builtin.command: id -u


### PR DESCRIPTION
Fixes "Risks of becoming an unprivileged user" errors during the setup process. This allows Ansible to successfully transition from the root/sudoer login to the unprivileged clawdbot user account during installation.