### PR TITLE
Fix the critical bug

### DIFF
--- a/roles/openclaw/tasks/openclaw.yml
+++ b/roles/openclaw/tasks/openclaw.yml
@@ -6,6 +6,14 @@
     fail_msg: "Invalid openclaw_install_mode: '{{ openclaw_install_mode }}'. Must be 'release' or 'development'."
     success_msg: "Valid install mode: {{ openclaw_install_mode }}"
 
+- name: Ensure openclaw home directory exists with correct ownership
+  ansible.builtin.file:
+    path: "{{ openclaw_home }}"
+    state: directory
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0755'
+
 - name: Create OpenClaw directories (structure only, no config files)
   ansible.builtin.file:
     path: "{{ item.path }}"
@@ -19,6 +27,10 @@
     - { path: "{{ openclaw_config_dir }}/credentials", mode: '0700' }
     - { path: "{{ openclaw_config_dir }}/data", mode: '0755' }
     - { path: "{{ openclaw_config_dir }}/logs", mode: '0755' }
+    - { path: "{{ openclaw_config_dir }}/agents", mode: '0755' }
+    - { path: "{{ openclaw_config_dir }}/agents/main", mode: '0755' }
+    - { path: "{{ openclaw_config_dir }}/agents/main/agent", mode: '0700' }
+    - { path: "{{ openclaw_config_dir }}/workspace", mode: '0755' }
 
 - name: Create pnpm directories
   ansible.builtin.file:

--- a/tests/verify.yml
+++ b/tests/verify.yml
@@ -35,6 +35,10 @@
         - { path: "{{ openclaw_home }}/.openclaw/credentials", mode: "0700" }
         - { path: "{{ openclaw_home }}/.openclaw/data" }
         - { path: "{{ openclaw_home }}/.openclaw/logs" }
+        - { path: "{{ openclaw_home }}/.openclaw/agents" }
+        - { path: "{{ openclaw_home }}/.openclaw/agents/main" }
+        - { path: "{{ openclaw_home }}/.openclaw/agents/main/agent", mode: "0700" }
+        - { path: "{{ openclaw_home }}/.openclaw/workspace" }
         - { path: "{{ openclaw_home }}/.ssh", mode: "0700" }
       register: dir_checks
 
@@ -46,10 +50,12 @@
       loop_control:
         label: "{{ item.item.path }}"
 
-    - name: Assert credentials dir has restricted permissions
+    - name: Assert restricted directories have correct permissions
       ansible.builtin.assert:
-        that: dir_checks.results[2].stat.mode == '0700'
-        fail_msg: "credentials dir should be 0700"
+        that:
+          - dir_checks.results[2].stat.mode == '0700'
+          - dir_checks.results[7].stat.mode == '0700'
+        fail_msg: "credentials and agents/main/agent dirs should be 0700"
 
     - name: Verify sudoers file exists and is valid
       ansible.builtin.command: visudo -cf /etc/sudoers.d/openclaw


### PR DESCRIPTION
  Root cause: The EACCES: permission denied error when creating /home/openclaw/.openclaw/agents/main/agent occurs because Node.js fs.mkdir() with { recursive: true } tries to create the entire path from scratch.
  If /home/openclaw/ itself doesn't exist yet (e.g., ansible failed or hasn't run), it tries to create it inside /home/ which is owned by root — causing EACCES.

  Changes made:

  1. roles/openclaw/tasks/openclaw.yml:
    - Added an explicit "Ensure openclaw home directory exists with correct ownership" task at the top of the openclaw setup (re-applies correct ownership as a safety net)
    - Pre-creates agents/, agents/main/, agents/main/agent/ (mode 0700 — matches what openclaw's pi-auth-json uses for credential storage) and workspace/ so openclaw doesn't need to create them on first run
  2. tests/verify.yml:
    - Added verification checks for the four new directories
    - Updated the permissions assertion to also validate agents/main/agent is mode 0700