### PR TITLE
Update repo references in documentation

### DIFF
--- a/docs/development-mode.md
+++ b/docs/development-mode.md
@@ -22,7 +22,7 @@ This guide explains how to install OpenClaw in **development mode**, where the a
 
 ```bash
 # Clone the ansible installer
-git clone https://github.com/pasogott/openclaw-ansible.git
+git clone https://github.com/openclaw/openclaw-ansible.git
 cd openclaw-ansible
 
 # Run in development mode
@@ -36,7 +36,7 @@ cd openclaw-ansible
 sudo apt update && sudo apt install -y ansible git
 
 # Clone repository
-git clone https://github.com/pasogott/openclaw-ansible.git
+git clone https://github.com/openclaw/openclaw-ansible.git
 cd openclaw-ansible
 
 # Install collections

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ description: Detailed installation and configuration instructions
 ## Quick Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pasogott/openclaw-ansible/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh | bash
 ```
 
 ## Manual Installation
@@ -23,7 +23,7 @@ sudo apt install -y ansible git
 ### Clone and Run
 
 ```bash
-git clone https://github.com/pasogott/openclaw-ansible.git
+git clone https://github.com/openclaw/openclaw-ansible.git
 cd openclaw-ansible
 
 # Install Ansible collections


### PR DESCRIPTION
# Summary

Update all repository URLs in documentation from `pasogott/openclaw-ansible` to `openclaw/openclaw-ansible` to reflect the move to the `openclaw` GitHub organization

# Changed files

`docs/development-mode.md`— updated clone URLs in quick start and manual install sections
`docs/installation.md` — updated curl install URL and clone URL

# Test plan
 
- [x] Verify the new GitHub URLs resolve correctly
- [x] Confirm no other files reference the old `pasogott` org