### PR TITLE
update `install.sh`: check for/install git, fix step numbering

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,22 +57,20 @@ echo -e "${GREEN}[1/4] Checking prerequisites...${NC}"
 
 # Check if Ansible is installed
 if ! command -v ansible-playbook &> /dev/null; then
-    echo -e "${YELLOW}Ansible not found. Installing...${NC}"
+    echo -e "${YELLOW}Ansible not found. Installing Ansible and git...${NC}"
     $SUDO apt-get update -qq
-    $SUDO apt-get install -y ansible
-    echo -e "${GREEN}✓ Ansible installed${NC}"
+    $SUDO apt-get install -y ansible git
+    echo -e "${GREEN}✓ Ansible and git installed${NC}"
 else
     echo -e "${GREEN}✓ Ansible already installed${NC}"
-fi
-
-# Check if git is installed
-if ! command -v git &> /dev/null; then
-    echo -e "${YELLOW}git not found. Installing...${NC}"
-    $SUDO apt-get update -qq
-    $SUDO apt-get install -y git
-    echo -e "${GREEN}✓ git installed${NC}"
-else
-    echo -e "${GREEN}✓ git already installed${NC}"
+    if ! command -v git &> /dev/null; then
+        echo -e "${YELLOW}git not found. Installing...${NC}"
+        $SUDO apt-get update -qq
+        $SUDO apt-get install -y git
+        echo -e "${GREEN}✓ git installed${NC}"
+    else
+        echo -e "${GREEN}✓ git already installed${NC}"
+    fi
 fi
 
 

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,18 @@ else
     echo -e "${GREEN}✓ Ansible already installed${NC}"
 fi
 
-echo -e "${GREEN}[2/5] Downloading playbook...${NC}"
+# Check if git is installed
+if ! command -v git &> /dev/null; then
+    echo -e "${YELLOW}git not found. Installing...${NC}"
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y git
+    echo -e "${GREEN}✓ git installed${NC}"
+else
+    echo -e "${GREEN}✓ git already installed${NC}"
+fi
+
+
+echo -e "${GREEN}[2/4] Downloading playbook...${NC}"
 
 # Download the playbook and role files
 cd "$TEMP_DIR"
@@ -77,10 +88,10 @@ cd openclaw-ansible
 
 echo -e "${GREEN}✓ Playbook downloaded${NC}"
 
-echo -e "${GREEN}[3/5] Installing Ansible collections...${NC}"
+echo -e "${GREEN}[3/4] Installing Ansible collections...${NC}"
 ansible-galaxy collection install -r requirements.yml
 
-echo -e "${GREEN}[4/5] Running Ansible playbook...${NC}"
+echo -e "${GREEN}[4/4] Running Ansible playbook...${NC}"
 if [ "$EUID" -ne 0 ]; then
     echo -e "${YELLOW}You will be prompted for your sudo password.${NC}"
 fi


### PR DESCRIPTION
# Summary

- Add a git availability check and auto-install step to `install.sh`, ensuring the script doesn't fail on minimal systems where git isn't pre-installed
- Fix step numbering to reflect the actual number of steps
 
