### PR TITLE
feat: support remote deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ vault.yml
 id_rsa*
 host_vars/
 group_vars/
+inventory.yml
+inventory.ini
+vars.yml
+vars-*.yml

--- a/README.md
+++ b/README.md
@@ -146,6 +146,38 @@ ansible-playbook playbook.yml --check --diff  # Dry run
 ansible-playbook playbook.yml --ask-become-pass
 ```
 
+## Remote Deployment
+
+To deploy OpenClaw to a remote server using SSH instead of running locally:
+
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone https://github.com/openclaw/openclaw-ansible.git
+   cd openclaw-ansible
+   ansible-galaxy collection install -r requirements.yml
+   ```
+
+2. Create your inventory file:
+   ```bash
+   cp inventory.example.yml inventory.yml
+   ```
+
+3. Edit `inventory.yml` with your server's IP and SSH details.
+
+4. Create a `vars.yml` file to specify the target hosts and any other configurations:
+   ```bash
+   cat > vars.yml << EOF
+   target_hosts: openclaw
+   EOF
+   ```
+
+5. Run the playbook targeting the remote server:
+   ```bash
+   ansible-playbook -i inventory.yml playbook.yml -e @vars.yml
+   ```
+
+*(Note: `inventory.yml` and `vars.yml` are ignored by git to protect your server credentials.)*
+
 ## Documentation
 
 - [Configuration Guide](docs/configuration.md) - All configuration options

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,38 @@ ansible-galaxy collection install -r requirements.yml
 ansible-playbook playbook.yml --ask-become-pass
 ```
 
+## Remote Deployment via SSH
+
+To deploy OpenClaw to a remote server instead of installing it locally:
+
+1. Clone the repository and install requirements on your local machine:
+   ```bash
+   git clone https://github.com/openclaw/openclaw-ansible.git
+   cd openclaw-ansible
+   ansible-galaxy collection install -r requirements.yml
+   ```
+
+2. Create an Ansible inventory file from the provided example:
+   ```bash
+   cp inventory.example.yml inventory.yml
+   ```
+
+3. Edit `inventory.yml` to specify your remote server's connection details (IP address, SSH user, key path, etc.).
+
+4. Create a `vars.yml` file to specify the target group from your inventory and any other options:
+   ```bash
+   cat > vars.yml << EOF
+   target_hosts: openclaw
+   EOF
+   ```
+   
+   *Note: `inventory.yml` and `vars.yml` are ignored by git so your server details and secrets will not be committed.*
+
+5. Run the playbook targeting the remote server:
+   ```bash
+   ansible-playbook -i inventory.yml playbook.yml -e @vars.yml
+   ```
+
 ## Post-Installation
 
 ### 1. Connect to Tailscale

--- a/inventory.example.yml
+++ b/inventory.example.yml
@@ -1,0 +1,22 @@
+# Example Ansible Inventory File for Remote Deployment
+#
+# Copy this file to inventory.yml (which is ignored by git)
+# and configure it with your remote server's details.
+#
+# Note: Variables like target_hosts, openclaw_install_mode, etc.,
+# should go in a separate vars.yml file instead of here.
+all:
+  children:
+    openclaw:
+      hosts:
+        openclaw_server:
+          # REQUIRED: The IP address or hostname of your target server
+          ansible_host: 192.168.1.100
+          
+          # REQUIRED: The SSH user to connect as
+          ansible_user: root  # Or ubuntu, debian, ec2-user, etc.
+          
+          # OPTIONAL SETTINGS:
+          # ansible_port: 2222
+          # ansible_ssh_private_key_file: ~/.ssh/id_rsa
+          # ansible_password: your_ssh_password (Not recommended)

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install OpenClaw with Docker and UFW firewall
-  hosts: localhost
-  connection: local
+  hosts: "{{ target_hosts | default('localhost') }}"
   become: true
 
   vars:


### PR DESCRIPTION
Use inventory file and templated `hosts` var to support remote deployment, keeping `localhost` as default, let Ansible auto adapt `connection`.

Fix: #9 