### PR TITLE
docs: add explicit verification checks to install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ openclaw status
 openclaw logs
 ```
 
+## Quick Verification
+
+Run these checks before you start onboarding real accounts:
+
+```bash
+# Service should be active
+sudo systemctl status openclaw --no-pager
+
+# OpenClaw should listen on localhost, not on all interfaces
+sudo ss -tlnp | grep -E '(:22|:41641|:3000)'
+
+# Firewall should allow SSH + Tailscale only
+sudo ufw status verbose
+
+# Docker isolation rule should still be present
+sudo iptables -L DOCKER-USER -n -v
+```
+
+Expected results:
+
+- `systemctl status` shows `Active: active (running)` for the `openclaw` service.
+- `ss -tlnp` shows SSH on `:22`, Tailscale on `:41641`, and the OpenClaw web UI bound to `127.0.0.1:3000` instead of `0.0.0.0:3000`.
+- `ufw status verbose` is `active` and only allows inbound SSH (`22/tcp`) and Tailscale (`41641/udp`) by default.
+- `iptables -L DOCKER-USER -n -v` includes a `DROP` rule for the default external interface, which prevents accidental public container exposure.
+
+For a longer verification checklist, including external port scanning and container-isolation checks, see [docs/installation.md#verification](docs/installation.md#verification) and [docs/security.md#verification](docs/security.md#verification).
+
 ## Manual Installation
 
 ### Release Mode (Default)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,6 +160,12 @@ curl http://localhost:80        # Should work
 sudo docker rm -f test-nginx
 ```
 
+Expected results:
+
+- `ss -tlnp` shows SSH on `:22`, Tailscale on `:41641`, and the OpenClaw web UI only on `127.0.0.1:3000`.
+- `nmap -p- YOUR_SERVER_IP` reports only `22/tcp` and your Tailscale UDP port as reachable from outside.
+- `curl http://YOUR_SERVER_IP:80` fails or times out, while `curl http://localhost:80` returns the nginx welcome page during the temporary isolation test.
+
 ### UFW Status
 
 ```bash
@@ -181,6 +187,8 @@ sudo tailscale status
 # Expected output:
 # 100.x.x.x    hostname    user@        linux   -
 ```
+
+The key thing to look for is that the machine appears in your tailnet and does not show as logged out or stopped.
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary
- add a quick verification checklist to the README right after post-install steps
- spell out the expected healthy output for the main verification commands in docs/installation.md
- link readers to the longer verification and security references from the README

Closes #26

## Testing
- git diff --check