### PR TITLE
docs: add deployed instances and apply ansible-lint fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,12 +2,12 @@
 profile: production
 
 skip_list:
-  - var-naming[no-role-prefix]  # Allow variables without role prefix
-  - risky-shell-pipe  # We handle pipefail where needed
-  - command-instead-of-module  # curl for GPG keys is intentional
+  - var-naming[no-role-prefix] # Allow variables without role prefix
+  - risky-shell-pipe # We handle pipefail where needed
+  - command-instead-of-module # curl for GPG keys is intentional
 
 warn_list:
-  - args[module]  # Warn on module args issues
+  - args[module] # Warn on module args issues
 
 kinds:
   - playbook: "**/playbook.yml"

--- a/.yamllint
+++ b/.yamllint
@@ -9,7 +9,7 @@ rules:
     spaces: 2
     indent-sequences: true
   truthy:
-    allowed-values: ['true', 'false']
+    allowed-values: ["true", "false"]
     check-keys: false
   comments:
     min-spaces-from-content: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,108 @@ Clean lifecycle, auto-start, logging integration.
 - Update CHANGELOG.md with user-facing changes
 - No version numbers in code (use git tags)
 
+## Deployed Instances
+
+### Donna (tripoli-v1)
+
+| Field | Value |
+|-------|-------|
+| **Public IP** | 46.250.242.89 |
+| **OS** | Ubuntu 24.04 LTS |
+| **Hostname** | donna |
+| **User** | `openclaw` (non-root, scoped sudo) |
+| **Tailscale IP** | 100.80.129.84 |
+| **Tailscale FQDN** | donna.taild24604.ts.net |
+| **Tailnet** | taild24604.ts.net |
+| **GitHub account** | donna-grooms |
+
+#### Gateway
+
+- **Dashboard:** `https://donna.taild24604.ts.net/`
+- **WebSocket:** `wss://donna.taild24604.ts.net`
+- **Auth mode:** token
+- **Bind:** loopback (Tailscale Serve proxies TLS)
+- **Tailscale mode:** serve (tailnet-only, not public funnel)
+- **Port:** 18789
+
+#### Headless Browser
+
+- **Profile:** `headless` (systemd user service: `chromium-headless.service`)
+- **CDP Port:** 18801
+- **Browser:** Chromium 145 (snap, headless)
+- Usage: `openclaw browser --browser-profile headless <command>`
+
+Note: `openclaw browser start` cannot launch snap Chromium through the gateway.
+The workaround is a separate systemd user service that runs Chromium with
+`--remote-debugging-port=18801`. The `headless` profile connects to it via CDP.
+
+#### Installed Tools
+
+| Tool | Package | Update command |
+|------|---------|----------------|
+| OpenClaw | openclaw | `pnpm install -g openclaw@latest` |
+| Claude Code | @anthropic-ai/claude-code | `pnpm install -g @anthropic-ai/claude-code` |
+| Codex CLI | @openai/codex | `pnpm install -g @openai/codex` |
+| gogcli | github.com/steipete/gogcli | `go install github.com/steipete/gogcli/cmd/gog@latest` |
+| GitHub CLI | gh (apt repo) | `apt-get update && apt-get upgrade gh` |
+| bird (X/Twitter) | @steipete/bird (deprecated) | `pnpm install -g @steipete/bird` |
+| clawhub | clawhub | `pnpm install -g clawhub` |
+| video-frames | video-frames | `pnpm install -g video-frames` |
+
+#### SSH Access
+
+```bash
+ssh openclaw@46.250.242.89       # via public IP
+ssh openclaw@donna               # via Tailscale
+```
+
+#### Post-Playbook Customizations
+
+Changes made after the Ansible playbook ran (not yet in playbook):
+
+1. **bashrc PATH fix**: Moved `PNPM_HOME` and `PATH` exports before the
+   non-interactive shell guard (`case $- in`) so tools work in non-interactive
+   SSH sessions.
+2. **Go bin in PATH**: Added `/home/openclaw/go/bin` to PATH.
+3. **npm prefix**: Set `npm config set prefix ~/.local` to avoid permission
+   errors on `npm install -g`.
+4. **Environment variables** (in bashrc, before non-interactive guard):
+   - `GOG_KEYRING_PASSWORD` / `GOG_KEYRING_BACKEND` — gogcli file keyring
+   - `CT0` / `AUTH_TOKEN` — X/Twitter cookies for bird CLI
+5. **Tailscale Serve**: `tailscale serve --bg http://127.0.0.1:18789`
+6. **Gateway config**: `tailscale.mode: "serve"`, `bind: "loopback"`
+7. **Device pairing**: Dashboard connections require `openclaw devices approve`
+
+### TARS
+
+| Field | Value |
+|-------|-------|
+| **Tailscale IP** | 100.95.24.62 |
+| **Tailscale FQDN** | tars.taild24604.ts.net |
+| **Dashboard** | `https://tars.taild24604.ts.net/` |
+
+### Inter-Instance Communication
+
+Both instances on the same tailnet. Each exposes its gateway via Tailscale Serve:
+
+```
+Donna -> https://tars.taild24604.ts.net/
+TARS  -> https://donna.taild24604.ts.net/
+```
+
+Webhook endpoints: `https://<hostname>.taild24604.ts.net/hooks`
+
+No public exposure. Encrypted via Tailscale. Zero config networking.
+
+### Tailnet Overview
+
+| Hostname | Tailscale IP | Role |
+|----------|-------------|------|
+| donna | 100.80.129.84 | OpenClaw instance |
+| tars | 100.95.24.62 | OpenClaw instance |
+| extractor-vps | 100.97.176.27 | Other |
+| gerds-macbook-pro | 100.98.25.89 | Dev machine |
+
 ## Support Channels
 
 - OpenClaw issues: https://github.com/openclaw/openclaw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/playbook.yml
+++ b/playbook.yml
@@ -82,7 +82,7 @@
       ansible.builtin.template:
         src: roles/openclaw/templates/show-lobster.sh.j2
         dest: /tmp/show-lobster.sh
-        mode: '0755'
+        mode: "0755"
 
     - name: Display ASCII art
       ansible.builtin.command: /tmp/show-lobster.sh
@@ -93,7 +93,7 @@
         dest: /home/openclaw/.openclaw-welcome
         owner: openclaw
         group: openclaw
-        mode: '0644'
+        mode: "0644"
         content: |
           echo ""
           echo "╔════════════════════════════════════════════════════════╗"
@@ -169,7 +169,7 @@
     - name: Add welcome message to .bashrc
       ansible.builtin.lineinfile:
         path: /home/openclaw/.bashrc
-        line: '[ -f ~/.openclaw-welcome ] && source ~/.openclaw-welcome'
+        line: "[ -f ~/.openclaw-welcome ] && source ~/.openclaw-welcome"
         state: present
         insertafter: EOF
 

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -6,8 +6,8 @@ ci_test: false
 
 # Tailscale settings
 # WARNING: Tasks using tailscale_authkey MUST set no_log: true to prevent credential exposure
-tailscale_enabled: false  # Set to true to install and configure Tailscale
-tailscale_authkey: ""  # Optional: set to auto-connect during installation
+tailscale_enabled: false # Set to true to install and configure Tailscale
+tailscale_authkey: "" # Optional: set to auto-connect during installation
 
 # Node.js version
 nodejs_version: "22.x"

--- a/roles/openclaw/tasks/docker-linux.yml
+++ b/roles/openclaw/tasks/docker-linux.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: /etc/apt/keyrings
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Add Docker GPG key
   ansible.builtin.shell:

--- a/roles/openclaw/tasks/firewall-linux.yml
+++ b/roles/openclaw/tasks/firewall-linux.yml
@@ -13,7 +13,7 @@
     dest: /etc/fail2ban/jail.local
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       # OpenClaw security hardening - SSH protection
       [DEFAULT]
@@ -48,7 +48,7 @@
     dest: /etc/apt/apt.conf.d/20auto-upgrades
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       APT::Periodic::Update-Package-Lists "1";
       APT::Periodic::Unattended-Upgrade "1";
@@ -59,7 +59,7 @@
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       // OpenClaw security hardening - automatic security updates
       Unattended-Upgrade::Allowed-Origins {
@@ -86,23 +86,23 @@
     direction: "{{ item.direction }}"
     policy: "{{ item.policy }}"
   loop:
-    - { direction: 'incoming', policy: 'deny' }
-    - { direction: 'outgoing', policy: 'allow' }
-    - { direction: 'routed', policy: 'deny' }
+    - { direction: "incoming", policy: "deny" }
+    - { direction: "outgoing", policy: "allow" }
+    - { direction: "routed", policy: "deny" }
 
 - name: Allow SSH on port 22
   community.general.ufw:
     rule: allow
-    port: '22'
+    port: "22"
     proto: tcp
-    comment: 'SSH'
+    comment: "SSH"
 
 - name: Allow Tailscale UDP port 41641
   community.general.ufw:
     rule: allow
-    port: '41641'
+    port: "41641"
     proto: udp
-    comment: 'Tailscale'
+    comment: "Tailscale"
   when: tailscale_enabled | bool
 
 - name: Get default network interface
@@ -145,7 +145,7 @@
   ansible.builtin.file:
     path: /etc/docker
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Configure Docker daemon to work with UFW
   ansible.builtin.template:
@@ -153,7 +153,7 @@
     dest: /etc/docker/daemon.json
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   notify: Restart docker
 
 - name: Enable UFW

--- a/roles/openclaw/tasks/nodejs.yml
+++ b/roles/openclaw/tasks/nodejs.yml
@@ -11,7 +11,7 @@
   ansible.builtin.file:
     path: /etc/apt/keyrings
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Add NodeSource GPG key
   ansible.builtin.shell:
@@ -51,6 +51,7 @@
 - name: Install pnpm globally
   ansible.builtin.command: npm install -g pnpm
   when: pnpm_check.rc != 0
+  changed_when: true
 
 - name: Verify Node.js installation
   ansible.builtin.command: node --version

--- a/roles/openclaw/tasks/openclaw-development.yml
+++ b/roles/openclaw/tasks/openclaw-development.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0755'
+    mode: "0755"
 
 - name: Check if openclaw repository already exists
   ansible.builtin.stat:
@@ -66,7 +66,7 @@
     PATH: "{{ openclaw_home }}/.local/bin:{{ openclaw_home }}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin"
     HOME: "{{ openclaw_home }}"
   register: pnpm_build_result
-  changed_when: true  # Build always changes dist/ directory
+  changed_when: true # Build always changes dist/ directory
 
 - name: Display build output
   ansible.builtin.debug:
@@ -100,7 +100,7 @@
 - name: Make openclaw binary executable
   ansible.builtin.file:
     path: "{{ openclaw_repo_dir }}/bin/openclaw.js"
-    mode: '0755'
+    mode: "0755"
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
 
@@ -139,4 +139,4 @@
     create: true
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0644'
+    mode: "0644"

--- a/roles/openclaw/tasks/openclaw.yml
+++ b/roles/openclaw/tasks/openclaw.yml
@@ -14,11 +14,11 @@
     group: "{{ openclaw_user }}"
     mode: "{{ item.mode }}"
   loop:
-    - { path: "{{ openclaw_config_dir }}", mode: '0755' }
-    - { path: "{{ openclaw_config_dir }}/sessions", mode: '0755' }
-    - { path: "{{ openclaw_config_dir }}/credentials", mode: '0700' }
-    - { path: "{{ openclaw_config_dir }}/data", mode: '0755' }
-    - { path: "{{ openclaw_config_dir }}/logs", mode: '0755' }
+    - { path: "{{ openclaw_config_dir }}", mode: "0755" }
+    - { path: "{{ openclaw_config_dir }}/sessions", mode: "0755" }
+    - { path: "{{ openclaw_config_dir }}/credentials", mode: "0700" }
+    - { path: "{{ openclaw_config_dir }}/data", mode: "0755" }
+    - { path: "{{ openclaw_config_dir }}/logs", mode: "0755" }
 
 - name: Create pnpm directories
   ansible.builtin.file:
@@ -26,7 +26,7 @@
     state: directory
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0755'
+    mode: "0755"
   loop:
     - "{{ openclaw_home }}/.local/share/pnpm"
     - "{{ openclaw_home }}/.local/share/pnpm/store"
@@ -39,7 +39,7 @@
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
     recurse: true
-    mode: '0755'
+    mode: "0755"
 
 - name: Configure pnpm for openclaw user
   ansible.builtin.shell:
@@ -87,7 +87,7 @@
     create: true
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0644'
+    mode: "0644"
     insertafter: EOF
 
 # NOTE: We do NOT create config.yml here - openclaw onboard/configure will do that

--- a/roles/openclaw/tasks/system-tools-linux.yml
+++ b/roles/openclaw/tasks/system-tools-linux.yml
@@ -50,4 +50,4 @@
     dest: /etc/vim/vimrc.local
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"

--- a/roles/openclaw/tasks/system-tools.yml
+++ b/roles/openclaw/tasks/system-tools.yml
@@ -12,14 +12,14 @@
     scope: global
     value: "{{ item.value }}"
   loop:
-    - { name: 'init.defaultBranch', value: 'main' }
-    - { name: 'pull.rebase', value: 'false' }
-    - { name: 'core.editor', value: 'vim' }
-    - { name: 'color.ui', value: 'auto' }
-    - { name: 'alias.st', value: 'status' }
-    - { name: 'alias.co', value: 'checkout' }
-    - { name: 'alias.br', value: 'branch' }
-    - { name: 'alias.ci', value: 'commit' }
-    - { name: 'alias.unstage', value: 'reset HEAD --' }
-    - { name: 'alias.last', value: 'log -1 HEAD' }
-    - { name: 'alias.lg', value: 'log --oneline --graph --decorate --all' }
+    - { name: "init.defaultBranch", value: "main" }
+    - { name: "pull.rebase", value: "false" }
+    - { name: "core.editor", value: "vim" }
+    - { name: "color.ui", value: "auto" }
+    - { name: "alias.st", value: "status" }
+    - { name: "alias.co", value: "checkout" }
+    - { name: "alias.br", value: "branch" }
+    - { name: "alias.ci", value: "commit" }
+    - { name: "alias.unstage", value: "reset HEAD --" }
+    - { name: "alias.last", value: "log -1 HEAD" }
+    - { name: "alias.lg", value: "log --oneline --graph --decorate --all" }

--- a/roles/openclaw/tasks/user.yml
+++ b/roles/openclaw/tasks/user.yml
@@ -15,7 +15,7 @@
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Configure .bashrc for openclaw user
   ansible.builtin.blockinfile:
@@ -41,12 +41,12 @@
     create: true
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0644'
+    mode: "0644"
 
 - name: Add openclaw user to sudoers with scoped NOPASSWD
   ansible.builtin.copy:
     dest: /etc/sudoers.d/openclaw
-    mode: '0440'
+    mode: "0440"
     owner: root
     group: root
     content: |
@@ -99,7 +99,7 @@
     dest: "{{ openclaw_home }}/.bash_profile"
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
-    mode: '0644'
+    mode: "0644"
     content: |
       # .bash_profile - Executed for login shells
       # Source .bashrc to ensure environment is loaded for login shells
@@ -130,7 +130,7 @@
     state: directory
     owner: openclaw
     group: openclaw
-    mode: '0700'
+    mode: "0700"
   when: ansible_os_family == 'Debian' and not ci_test
 
 - name: Store openclaw UID as fact for later use
@@ -145,7 +145,7 @@
     state: directory
     owner: openclaw
     group: openclaw
-    mode: '0700'
+    mode: "0700"
 
 - name: Add SSH authorized keys for openclaw user
   ansible.posix.authorized_key:
@@ -168,12 +168,12 @@
 - name: Set XDG_RUNTIME_DIR in .bashrc for openclaw user
   ansible.builtin.lineinfile:
     path: /home/openclaw/.bashrc
-    line: 'export XDG_RUNTIME_DIR=/run/user/$(id -u)'
+    line: "export XDG_RUNTIME_DIR=/run/user/$(id -u)"
     state: present
     create: true
     owner: openclaw
     group: openclaw
-    mode: '0644'
+    mode: "0644"
   when: ansible_os_family == 'Debian' and not ci_test
 
 - name: Set DBUS_SESSION_BUS_ADDRESS in .bashrc for openclaw user
@@ -190,5 +190,5 @@
     create: true
     owner: openclaw
     group: openclaw
-    mode: '0644'
+    mode: "0644"
   when: ansible_os_family == 'Debian' and not ci_test

--- a/tests/verify.yml
+++ b/tests/verify.yml
@@ -59,12 +59,14 @@
       ansible.builtin.stat:
         path: /etc/vim/vimrc.local
       register: vimrc
-    - ansible.builtin.assert:
+    - name: Assert vimrc exists
+      ansible.builtin.assert:
         that: vimrc.stat.exists
 
     - name: Verify git global config
       ansible.builtin.command: git config --global init.defaultBranch
       changed_when: false
       register: git_branch
-    - ansible.builtin.assert:
+    - name: Assert git default branch is main
+      ansible.builtin.assert:
         that: git_branch.stdout == 'main'


### PR DESCRIPTION
## Summary

- Add deployed instance documentation to AGENTS.md: Donna (tripoli-v1) and TARS instances, tailnet topology, installed tools, gateway/browser config, SSH access, and post-playbook customizations
- Add CLAUDE.md symlink pointing to AGENTS.md
- Apply ansible-lint formatting fixes: normalize quote style to double quotes, add missing `changed_when`, add missing task names to assert blocks

## Test plan

- [x] Verify AGENTS.md renders correctly on GitHub
- [x] Run `ansible-lint` to confirm no remaining violations
- [x] Run `ansible-playbook playbook.yml --syntax-check` to verify no regressions