### PR TITLE
fix(deps): clear ansible-core security alerts

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,3 @@
-ansible-core==2.15.13
+ansible-core==2.16.19
 ansible-lint==6.22.2
 yamllint==1.37.1


### PR DESCRIPTION
## What Problem This Solves

Resolves the three open `ansible-core` Dependabot alerts in the lint and syntax-check dependency set:

- Alert 1, low: https://github.com/openclaw/openclaw-ansible/security/dependabot/1
  - GHSA-99w6-3xph-cx78: https://github.com/advisories/GHSA-99w6-3xph-cx78
  - Vulnerable range: `< 2.16.14rc1`
- Alert 2, high: https://github.com/openclaw/openclaw-ansible/security/dependabot/2
  - GHSA-jpxc-vmjf-9fcj: https://github.com/advisories/GHSA-jpxc-vmjf-9fcj
  - Vulnerable range: `< 2.16.13`
- Alert 3, high: https://github.com/openclaw/openclaw-ansible/security/dependabot/3
  - GHSA-w8p5-mx5w-cpqj: https://github.com/advisories/GHSA-w8p5-mx5w-cpqj
  - Vulnerable range: `< 2.16.19rc1`

## Why This Change Was Made

Pins the lint and syntax-check environment to stable `ansible-core==2.16.19`. This is the smallest stable patch-line update that clears all three advisory ranges without selecting a release candidate or changing the playbook runtime surface.

## User Impact

No installer behavior changes. Maintainer lint and syntax-check jobs use a patched stable Ansible Core release instead of the vulnerable 2.15.13 pin.

## Evidence

- Signed commit: `e0ed2294270cd37bb14a4d9358f44376431230ae`
- `python -m pip install -r requirements-lint.txt`
- `ansible-galaxy collection install -r requirements.yml`
- `yamllint .`
- `ansible-lint playbook.yml`: passed, 0 failures and 0 lint warnings across 15 files
- `ansible-playbook playbook.yml --syntax-check`: passed
- `python -m pip check`: no broken requirements
- `ansible --version`: core 2.16.19
- Structured autoreview: clean, no accepted or actionable findings

The latest resolved `community.general` collection emits its existing support-range warning for Ansible Core 2.16, but lint and syntax validation complete successfully.
