### PR TITLE
fix: remove root-equivalent Docker access from service user

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Run ansible-lint
-        run: ansible-lint playbook.yml
+        run: ansible-lint playbook.yml tests/docker-group-security.yml
 
   syntax-check:
     name: Ansible Syntax Check
@@ -67,4 +67,24 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Ansible syntax check
-        run: ansible-playbook playbook.yml --syntax-check
+        run: |
+          ansible-playbook playbook.yml --syntax-check
+          ansible-playbook tests/docker-group-security.yml --syntax-check
+
+  docker-group-security:
+    name: Docker Group Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Ansible
+        run: python -m pip install -r requirements-lint.txt
+
+      - name: Verify service-user Docker access is removed
+        run: ansible-playbook tests/docker-group-security.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the OpenClaw service user from the root-equivalent Docker group, including on existing installations. Thanks @Tonynanra for the report.
 - Document expected results for post-install security verification and link the checks from setup documentation. Thanks @justinfiore for the report.
 
 ## [2.0.0] - 2025-01-09

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Enable with: `-e openclaw_install_mode=development`
 - **Automatic updates**: Security patches via unattended-upgrades
 - **Docker isolation**: Containers can't expose ports externally (DOCKER-USER chain)
 - **Non-root**: OpenClaw runs as unprivileged user
+- **No Docker socket access**: The OpenClaw user is excluded from the root-equivalent `docker` group
 - **Scoped sudo**: Limited to service management (not full root)
 - **Systemd hardening**: NoNewPrivileges, PrivateTmp, ProtectSystem
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ systemd → docker compose → openclaw container
 
 3. **Docker Installation** (`docker.yml`)
    - Install Docker CE + Compose V2
-   - Add user to docker group
+   - Keep the OpenClaw service user out of the root-equivalent Docker group
    - Create `/etc/docker` directory
 
 4. **Firewall Setup** (`firewall.yml`)

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,11 @@ The openclaw user has limited sudo permissions (not full root):
 - journalctl for openclaw logs
 ```
 
+The user is deliberately excluded from the `docker` group. Membership would
+grant root-equivalent control through the rootful Docker daemon and bypass the
+scoped sudo boundary. Reapplying the playbook also removes this legacy grant
+from existing installations without changing other supplementary groups.
+
 ### Layer 8: Automatic Security Updates
 
 Unattended-upgrades is configured for automatic security patches:
@@ -144,6 +149,15 @@ sudo iptables -L DOCKER-USER -n -v
 ```
 
 Expected: the chain includes accepts for established traffic and loopback traffic, followed by a drop rule for traffic arriving on the server's default external interface. Packet counters may be zero before traffic reaches the chain.
+
+Verify that the OpenClaw service account cannot access the Docker socket:
+
+```bash
+id -nG openclaw
+```
+
+Expected: the output does not include `docker`. Operators should use `sudo
+docker ...` for explicit container administration.
 
 From another machine, scan the server:
 
@@ -229,6 +243,7 @@ After installation, verify:
 - [ ] `sudo ufw status` shows only SSH and Tailscale allowed
 - [ ] `sudo fail2ban-client status sshd` shows jail active
 - [ ] `sudo iptables -L DOCKER-USER -n` shows DROP rule
+- [ ] `id -nG openclaw` does not include the `docker` group
 - [ ] `nmap -p- YOUR_IP` from external shows only port 22
 - [ ] `docker run -p 80:80 nginx` + `curl YOUR_IP:80` times out
 - [ ] Tailscale access works for web UI

--- a/roles/openclaw/tasks/docker-linux.yml
+++ b/roles/openclaw/tasks/docker-linux.yml
@@ -59,11 +59,5 @@
     state: started
     enabled: true
 
-- name: Add user to docker group
-  ansible.builtin.user:
-    name: "{{ openclaw_user }}"
-    groups: docker
-    append: true
-
-- name: Reset SSH connection to apply docker group
-  ansible.builtin.meta: reset_connection
+- name: Enforce least-privilege Docker access
+  ansible.builtin.include_tasks: docker-security.yml

--- a/roles/openclaw/tasks/docker-security.yml
+++ b/roles/openclaw/tasks/docker-security.yml
@@ -1,0 +1,20 @@
+---
+# The rootful Docker socket grants host-root-equivalent control. OpenClaw runs
+# on the host and does not need daemon access, so remove the legacy grant while
+# preserving every unrelated supplementary group an operator may have added.
+- name: Read Docker group membership
+  ansible.builtin.getent:
+    database: group
+    key: docker
+
+- name: Remove OpenClaw service user from root-equivalent Docker group
+  ansible.builtin.command:
+    argv:
+      - gpasswd
+      - --delete
+      - "{{ openclaw_user }}"
+      - docker
+  changed_when: true
+  when: >-
+    openclaw_user in
+    (ansible_facts.getent_group['docker'][2].split(',') | reject('equalto', '') | list)

--- a/tests/docker-group-security.yml
+++ b/tests/docker-group-security.yml
@@ -1,0 +1,72 @@
+---
+- name: Verify Docker group privilege migration
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: false
+
+  vars:
+    openclaw_user: openclaw-security-test
+    openclaw_test_extra_group: openclaw-test-extra
+
+  tasks:
+    - name: Create test groups
+      ansible.builtin.group:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - docker
+        - "{{ openclaw_test_extra_group }}"
+
+    - name: Create intentionally overprivileged service user fixture
+      ansible.builtin.user:
+        name: "{{ openclaw_user }}"
+        groups:
+          - docker
+          - "{{ openclaw_test_extra_group }}"
+        append: true
+        create_home: false
+        system: true
+
+    - name: Read fixture group memberships
+      ansible.builtin.command:
+        argv:
+          - id
+          - -nG
+          - "{{ openclaw_user }}"
+      register: openclaw_groups_before
+      changed_when: false
+
+    - name: Assert vulnerable fixture and unrelated group are present
+      ansible.builtin.assert:
+        that:
+          - "'docker' in openclaw_groups_before.stdout.split()"
+          - "openclaw_test_extra_group in openclaw_groups_before.stdout.split()"
+
+    - name: Apply production Docker service-account hardening
+      ansible.builtin.include_role:
+        name: openclaw
+        tasks_from: docker-security
+
+    - name: Read migrated group memberships
+      ansible.builtin.command:
+        argv:
+          - id
+          - -nG
+          - "{{ openclaw_user }}"
+      register: openclaw_groups_after
+      changed_when: false
+
+    - name: Assert Docker access is removed without disturbing other groups
+      ansible.builtin.assert:
+        that:
+          - "'docker' not in openclaw_groups_after.stdout.split()"
+          - "openclaw_test_extra_group in openclaw_groups_after.stdout.split()"
+        success_msg: >-
+          The service user cannot access the rootful Docker daemon and retains
+          unrelated supplementary groups.
+
+    - name: Reapply Docker service-account hardening
+      ansible.builtin.include_role:
+        name: openclaw
+        tasks_from: docker-security


### PR DESCRIPTION
## Summary

- stop granting the OpenClaw service account access to the rootful Docker daemon
- remove the legacy Docker group membership from existing installations without disturbing other supplementary groups
- document and continuously test the least-privilege boundary

## Security rationale

Membership in the Docker group grants control of the rootful daemon and is therefore host-root-equivalent. OpenClaw is installed and onboarded as a host process, while Docker is provided for sandboxes, so the service account does not need direct daemon access.

The migration uses a targeted group deletion rather than replacing the account's supplementary-group list. This closes the privilege-escalation path while preserving operator-managed memberships.

PR #51 explores a broader rootless Podman runtime for Fedora/RHEL support. That platform expansion is independent of this fix and is not required to restore the current Debian/Ubuntu security boundary.

## Proof

- Ubuntu 24.04 container behavior test: starts with the service account in both Docker and an unrelated group; removes Docker only; second application skips cleanly
- Ansible syntax checks pass for the main playbook and regression playbook
- ansible-lint production profile: 0 failures, 0 warnings
- yamllint: clean
- structured autoreview: clean

Fixes #32
